### PR TITLE
Revert "Bump resteasy.version from 4.5.9.Final to 4.6.1.Final"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
         <smallrye-graphql.version>1.2.5</smallrye-graphql.version>
         <quarkus.version>1.13.7.Final</quarkus.version>
-        <resteasy.version>4.6.1.Final</resteasy.version>
+        <resteasy.version>4.5.9.Final<!-- the version used by quarkus --></resteasy.version>
         <lombok.version>1.18.20</lombok.version>
 
         <junit.version>5.7.2</junit.version>


### PR DESCRIPTION
Reverts t1/wunderbar#61

throws `java.util.MissingResourceException: Can't find bundle for base name javax.servlet.LocalStrings, locale en_DE`