### PR TITLE
Revert "Bump resteasy.version from 4.6.1.Final to 4.7.1.Final"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
         <smallrye-graphql.version>1.2.8</smallrye-graphql.version>
         <quarkus.version>2.1.0.Final</quarkus.version>
-        <resteasy.version>4.7.1.Final</resteasy.version>
+        <resteasy.version>4.6.1.Final<!-- the version used by quarkus --></resteasy.version>
         <lombok.version>1.18.20</lombok.version>
 
         <junit.version>5.7.2</junit.version>


### PR DESCRIPTION
Reverts t1/wunderbar#83 as we want the version used in Quarkus